### PR TITLE
Optimal config for targeting Node.js 8.10.0 or newer. 100% of ES2017 is supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typedmvc",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Typescript Web MVC Framework built on-top of ExpressJS",
   "main": "./lib/TypedMVC.js",
   "types": "./typings/TypedMVC.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+    "target": "es2017",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["es2015", "dom"],                 /* Specify library files to be included in the compilation:  */
+    "lib": ["es2017", "dom"],                 /* Specify library files to be included in the compilation:  */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
Hello,

Using ES2017 with latest Node.js versions results in using native async/await instead of the generator/yield garbage.

Bumping the TypedMVC version 0.3.0 as this implies backward incompatibility with Node.js 6 or any version older than 8.10.0.

Can you please publish 0.2.0 and this one to npm?
Thanks.

Regards,
Jorge Oliveira